### PR TITLE
Fix CodecPack wrapper (ffmpeg33)

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -2,7 +2,7 @@
 
 function restart_videostation() {
 	if [[ -d /var/packages/CodecPack/target/bin ]]; then
-  		echo "[INFO] Restarting CodecPack"
+  		echo "[INFO] Restarting CodecPack..."
 		synopkg restart CodecPack
 	fi
 
@@ -47,9 +47,15 @@ function armv8_procedure() {
 	done
 
 	if [[ -d /var/packages/CodecPack/target/lib/ffmpeg27 ]]; then
-		echo "[INFO] Creating symbolic link from CodecPack ffmpeg directory"
+		echo "[INFO] Saving current Advanced Media Extensions ffmpeg27 as ffmpeg27.orig"
 		mv /var/packages/CodecPack/target/lib/ffmpeg27 /var/packages/CodecPack/target/lib/ffmpeg27.orig
-		ln -s /var/packages/VideoStation/target/lib/ffmpeg /var/packages/CodecPack/target/lib/ffmpeg27
+
+		echo "[INFO] Copying VideoStation's ffmpeg to CodecPack ffmpeg27"
+		cp /var/packages/VideoStation/target/bin/ffmpeg /var/packages/CodecPack/target/bin/ffmpeg27
+
+		sed -i 's/bin1=\/var\/packages\/VideoStation\/target\/bin\/ffmpeg.orig/bin1=\/var\/packages\/CodecPack\/target\/bin\/ffmpeg27.orig/' /var/packages/CodecPack/target/bin/ffmpeg27
+
+		chmod 755 /var/packages/CodecPack/target/bin/ffmpeg33
 	fi
 
   	save_and_patch
@@ -78,6 +84,8 @@ function others_procedure() {
 
 		echo "[INFO] Copying VideoStation's ffmpeg to CodecPack ffmpeg33"
 		cp /var/packages/VideoStation/target/bin/ffmpeg /var/packages/CodecPack/target/bin/ffmpeg33
+
+		sed -i 's/bin1=\/var\/packages\/VideoStation\/target\/bin\/ffmpeg.orig/bin1=\/var\/packages\/CodecPack\/target\/bin\/ffmpeg33.orig/' /var/packages/CodecPack/target/bin/ffmpeg33
 
 		chmod 755 /var/packages/CodecPack/target/bin/ffmpeg33
 	fi


### PR DESCRIPTION
Fix #4 

ARMv8:
Fixed symbolic link referencing the VideoStation ffmpeg-wrapper without using `ffmpeg27.orig` as bin1

x64:
Fixed copied ffmpeg-wrapper not using `ffmpeg33.orig` as bin1