### PR TITLE
fix: Thumbnail generation is not possible in VideoStation.

### DIFF
--- a/ffmpeg-wrapper.sh
+++ b/ffmpeg-wrapper.sh
@@ -31,7 +31,7 @@ function endprocess() {
   info "========================================[end ffmpeg $pid]"
   newline
   rm -f "$stderrfile"
-  exit 1
+  exit 0
 }
 
 #########################


### PR DESCRIPTION
This is a very simple fix, but if left unfixed it can cause VideoStation to be unable to generate thumbnails. 

Of course, it may not be elegant enough. You can patch it up if necessary. 

I have provided detailed reasons and analysis in this issue. #61 